### PR TITLE
Add viz function to show shapes with matplotlib

### DIFF
--- a/clusterpy/core/__init__.py
+++ b/clusterpy/core/__init__.py
@@ -11,3 +11,5 @@ __email__ = "contacto@rise-group.org"
 from inputs import *
 from layer import Layer
 from contiguity import *
+from viz import showshape
+from viz import showshapes

--- a/clusterpy/core/viz.py
+++ b/clusterpy/core/viz.py
@@ -1,12 +1,32 @@
 def showshape(shape, colorarray=None, colormap=None, alpha=None):
   """
   Creates and displays a firgure for the given shape using Matplotlib
+  Parameters:
+    [Shape] is a Clusterpy layer.
+    [colorarray] is an array, with the same number of elements as areas in the
+      layer, that is used to categorize the areas and set the color according to
+      the value.
+    [colormap] a string representing a Matplotlib's cmap name.
+    [alpha] the alpha for the colors.
+
+  Returns:
+    A Matplotlib's figure.
   """
   return showshapes([shape], colorarray, colormap, alpha)
 
 def showshapes(shapes, colorarray=None, colormap=None, alpha=None):
   """
   Creates and displays in a grid the group of shapes given.
+  Parameters:
+    [Shapes] a list of Clusterpy layers.
+    [colorarray] is an array, with the same number of elements as areas in the
+      layers, that is used to categorize the areas and set the color according to
+      the value.
+    [colormap] a string representing a Matplotlib's cmap name.
+    [alpha] the alpha for the colors.
+
+  Returns:
+    A Matplotlib's grid of figures.
   """
   try:
     import matplotlib.patches as pts

--- a/clusterpy/core/viz.py
+++ b/clusterpy/core/viz.py
@@ -1,0 +1,51 @@
+def showshape(shape):
+  """
+  Creates and displays a firgure for the given shape using Matplotlib
+  """
+  return showshapes([shape])
+
+def showshapes(shapes):
+  """
+  Creates and displays in a grid the group of shapes given.
+  """
+  try:
+    import matplotlib.patches as pts
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from matplotlib.cm import jet
+    from matplotlib.collections import PatchCollection
+  except ImportError:
+    print "Matplotlib's pyplot or patches not found."
+    return
+
+  num_figs = len(shapes)
+  x, y = 1, 1
+  mult = 1
+  if num_figs > 1:
+    mult = 2
+    if num_figs % 2 == 0:
+        x, y = 2, max(2, num_figs/2)
+    else:
+        x, y = 3, max(2, int(np.ceil(num_figs/3.0)))
+
+  fig = plt.figure(figsize=(8*mult, 6*mult), dpi=80)
+  for pos, lay in enumerate(shapes):
+    ax = plt.subplot(x, y, 1 + pos)
+    patches = []
+    for vertices in lay.areas:
+        polygon = pts.Polygon(vertices[0], closed=True)
+        patches.append(polygon)
+
+    xmin, ymin, xmax, ymax = lay.getBbox()
+    ax.set_xlim(xmin, xmax)
+    ax.set_ylim(ymin, ymax)
+
+    colors = 100*np.random.rand(len(patches))
+    pcoll = PatchCollection(patches, cmap=jet, alpha=0.4)
+    pcoll.set_array(np.array(colors))
+    ax.add_collection(pcoll)
+    ax.set_xticks([])
+    ax.set_yticks([])
+    for spine in ax.spines.values():
+      spine.set_visible(False)
+  plt.plot()

--- a/clusterpy/core/viz.py
+++ b/clusterpy/core/viz.py
@@ -1,10 +1,10 @@
-def showshape(shape):
+def showshape(shape, colorarray=None, colormap=None, alpha=None):
   """
   Creates and displays a firgure for the given shape using Matplotlib
   """
-  return showshapes([shape])
+  return showshapes([shape], colorarray, colormap, alpha)
 
-def showshapes(shapes):
+def showshapes(shapes, colorarray=None, colormap=None, alpha=None):
   """
   Creates and displays in a grid the group of shapes given.
   """
@@ -12,10 +12,9 @@ def showshapes(shapes):
     import matplotlib.patches as pts
     import matplotlib.pyplot as plt
     import numpy as np
-    from matplotlib.cm import jet
     from matplotlib.collections import PatchCollection
   except ImportError:
-    print "Matplotlib's pyplot or patches not found."
+    print "Matplotlib's pyplot patches and/or collections not found."
     return
 
   num_figs = len(shapes)
@@ -40,8 +39,19 @@ def showshapes(shapes):
     ax.set_xlim(xmin, xmax)
     ax.set_ylim(ymin, ymax)
 
-    colors = 100*np.random.rand(len(patches))
-    pcoll = PatchCollection(patches, cmap=jet, alpha=0.4)
+    cmap = plt.get_cmap('jet') if colormap is None else plt.get_cmap(colormap)
+    calpha = 0.4 if alpha is None else alpha
+    colors = []
+    areas_count = len(patches)
+
+    if colorarray is None:
+      colors = 100 * np.random.rand(areas_count)
+    else:
+      if len(colorarray) != areas_count:
+        raise Exception("The colorarray has to specify a value for one and only one area")
+      colors = colorarray
+
+    pcoll = PatchCollection(patches, cmap=cmap, alpha=calpha)
     pcoll.set_array(np.array(colors))
     ax.add_collection(pcoll)
     ax.set_xticks([])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 nose
 scipy
 Polygon2
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ try:
   import numpy
   import scipy
 except ImportError:
-  sys.exit("install requires: 'numpy', 'scipy'")
+  sys.exit("install requires: 'numpy', 'scipy'" +
+    "optional packages: 'matplotlib', 'Polygon2'")
 
-# Polygon2 is actually optional
-install_requires = ['numpy', 'scipy', 'Polygon2']
+install_requires = ['numpy', 'scipy', 'matplotlib', 'Polygon2']
 test_requires = ['nose']
 
 setup(name = 'clusterpy',


### PR DESCRIPTION
Now calling clusterpy.showshape(shape) or clusterpy.showshapes(shapes)
where shape and shapes are a layer object or an array of layer objects
respectively will present the shapes using matplotlibs pyplot.
This closes #14 but it's experimental