### PR TITLE
Set seed as 32 bit integer

### DIFF
--- a/clusterpy/core/toolboxes/cluster/componentsAlg/regionmaker.py
+++ b/clusterpy/core/toolboxes/cluster/componentsAlg/regionmaker.py
@@ -281,7 +281,7 @@ class RegionMaker:
         seeds = []
         localDistanceType = self.distanceType
         returnDistance2Area = AreaCl.returnDistance2Area
-        nprandom.seed(int(time() * getpid()))
+        nprandom.seed(int(time() * getpid()) % 4294967295)
         for k in xrange(self.pRegions):
             random = nprandom.uniform(0, 1)
             find = False

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -106,6 +106,20 @@ class TestMaxPTabu(TestCase):
 
         self.assertTrue(initial_obj_func >= final_obj_func)
 
+    @attr('slow')
+    def test_maxpt_min_num_areas_in_region_threshold(self):
+        instance = self.map_instance
+        from collections import Counter as cnt
+
+        instance.dataOperation("CONSTANTS = 1")
+
+        thresholds = [5, 8, 13, 21, 34]
+
+        for threshold in thresholds:
+            instance.cluster('maxpTabu', ['CONSTANTS'], threshold=threshold)
+            region_size = cnt(instance.region2areas).values()
+            self.assertTrue(all(item >= threshold for item in region_size))
+
 class TestAZPalgorithms(TestCase):
     """ Tests for AZP, AZPrTabu, AZPSA """
     def setUp(self):
@@ -221,4 +235,3 @@ class TestAZPalgorithms(TestCase):
         ob_after = rm.objInfo
 
         self.assertTrue(ob_before >= ob_after)
-


### PR DESCRIPTION
Numpy seed only accepts 32 bit integer now. Previous method in clusterpy
was passing larger numbers.

Ref:
https://github.com/numpy/numpy/commit/6b1a1205eac6fe5d162f16155d500765e8bca53c

Added also one test for threshold and number of regions.